### PR TITLE
fix: remove duplicate semicolon

### DIFF
--- a/packages/starlight-theme-obsidian/styles/common.css
+++ b/packages/starlight-theme-obsidian/styles/common.css
@@ -509,7 +509,7 @@ footer {
     background-color: var(--sl-color-bg-badge);
 
     &.default {
-        --sl-color-bg-badge: var(--sl-badge-default-bg);;
+        --sl-color-bg-badge: var(--sl-badge-default-bg);
     }
 
     &.note {


### PR DESCRIPTION
Fix the error where duplicated semicolon is preventing the starlight to build.

For starlight 0.32.5 it throws error on building step because of duplicate semicolon typo. 

Error is throwed in environment with dependencies below:

`@astrojs/starlight`: `0.32.5`,
 `@tailwindcss/vite`: `4.0.17`,
`astro`: `5.5.3`,
`starlight-theme-obsidian`: `0.2.1`,
`tailwindcss`: `4.0.17`